### PR TITLE
Added test script for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,21 @@ cd corelang-test-files
 ./run_tests.sh [path to your interpreter]
 ```
 
-You may need to modify this slightly depending on your system.
+To run an interpreter compiled from C/C++:
+
+```sh
+./run_tests.sh [path to your interpreter]
+```
+
+To run an interpreter from a Python 3 script:
+
+```sh
+./run_python3_tests.sh [path to your interpreter]
+```
+
+To run an interpreter from a Python 2 script, open `run_python3_tests.sh` and change lines 39 and 49 to use the `python` executable instead.
+
+You may need to continue to modify this slightly depending on your system.
 
 
 ## Test and naming conventions

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ language. Not official; please use according to your own best judgement.
 ```sh
 git clone https://github.com/zqianem/corelang-test-files.git
 cd corelang-test-files
-
-./run_tests.sh [path to your interpreter]
 ```
 
 To run an interpreter compiled from C/C++:

--- a/run_python3_tests.sh
+++ b/run_python3_tests.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+if [ "$1" = "" ]
+then
+  echo Tests not run, missing first argument
+  echo usage: $0 [path_to_interpreter_script]
+  exit 1
+fi
+
+if [ $# -gt 1 ]
+then
+  echo Ignoring extra arguments beyond the first...
+fi
+
+if ! hash "$1" 2>/dev/null
+then
+  echo Tests not run, could not find command "$1"
+  exit 1
+fi
+
+tests="**/*.code"
+
+for t in $tests
+do
+  t=${t%\.code}
+  code=$t.code
+  data=$t.data
+  expected=$t.expected
+
+  if [ ! -f $data ]
+  then
+    data=empty.data
+  fi
+
+  printf "Testing %s... " "$t"
+
+  if [ $t != "${t%bad*}" ]
+  then
+    output=$(python3 $1 $code $data)
+    if [ "$output" != "${output%ERROR:*}" ]
+    then
+      printf "\033[0;32mPASSED\033[0m\n"
+    else
+      printf "\033[0;31mFAILED\033[0m\n"
+      printf "\033[1mexpected error, got following output:\033[0m\n"
+      echo "$output"
+    fi
+  else
+    output=$(python3 $1 $code $data | diff -u - $expected)
+    if [ $? -eq 0 ]
+    then
+      printf "\033[0;32mPASSED\033[0m\n"
+    else
+      printf "\033[0;31mFAILED\033[0m\n"
+      echo "$output"
+    fi
+  fi
+done


### PR DESCRIPTION
The run_tests.sh script assumes an executable which requires no additional arguments other than the Core test files, which is true for an interpreter created in C/C++ but not in Java or Python. This PR adds a test script for Python 3 script files and instructions for adapting to a Python 2 script. Further work could add a Java script as well.